### PR TITLE
Feature/pc parts scraper/mobo

### DIFF
--- a/app/models/mobo.rb
+++ b/app/models/mobo.rb
@@ -1,3 +1,51 @@
 class Mobo < ApplicationRecord
   has_many :builds, dependent: :destroy
+
+  def self.name
+    @name = 'mobos'
+  end
+
+  def self.url
+    @start_urls = ["https://pangoly.com/en/browse/motherboard?page=#{@page}"]
+  end
+
+  def self.parse_repo_page(response)
+    item = {}
+    @table = response.xpath("//table[@class='table table-bordered table-striped table-hover']/tbody")
+    item[:socket_cpu] = get_text('Socket')
+    item[:form_factor] = get_text('Form factor')
+    item[:max_memory] = get_text('Maximum Supported RAM')
+    item[:memory_slots] = get_text('RAM Slots')
+    item[:price] = response.xpath("//span[@class='price']").text.tr('^0-9.', '').to_f
+    item[:name] = response.xpath("//div[contains(@class, 'product-info')]").css('h2').text
+    item[:image] = response.xpath("//img[@class='nivo-main-image']").attr('src').value
+    item[:supported_memory] = []
+    response.xpath("//div[@class='ram-values text-left']/span").each do |speed|
+      ddr = get_text('Supported Memory').tr(':', '-').split.first
+      speed = speed.text.squish
+      item[:supported_memory].push(ddr + speed)
+    end
+    find_or_create_by(item)
+  end
+
+  def self.get_text(column)
+    info = @table.css('tr').xpath("//strong[text()='#{column}']").xpath('..').xpath('..').css('td')[1]
+    return nil unless info
+
+    info.text.squish
+  end
+
+  def self.get_int(column)
+    info = @table.css('tr').xpath("//strong[text()='#{column}']").xpath('..').xpath('..').css('td')[1]
+    return nil unless info
+
+    info.text.squish.to_i
+  end
+
+  def self.get_arr(column)
+    info = @table.css('tr').xpath("//strong[text()='#{column}']").xpath('..').xpath('..').css('td')[1]
+    return nil unless info
+
+    info.css('ul/li').map(&:text)
+  end
 end

--- a/db/migrate/20210719064713_edit_mobos_socket_cpu_supported_memory_max_memory_data_type.rb
+++ b/db/migrate/20210719064713_edit_mobos_socket_cpu_supported_memory_max_memory_data_type.rb
@@ -1,0 +1,7 @@
+class EditMobosSocketCpuSupportedMemoryMaxMemoryDataType < ActiveRecord::Migration[6.0]
+  def change
+    change_column :mobos, :socket_cpu, :string
+    change_column :mobos, :supported_memory, "varchar[] USING (string_to_array(supported_memory, ','))"
+    change_column :mobos, :max_memory, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_17_081433) do
+ActiveRecord::Schema.define(version: 2021_07_19_064713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,9 +149,9 @@ ActiveRecord::Schema.define(version: 2021_07_17_081433) do
   end
 
   create_table "mobos", force: :cascade do |t|
-    t.string "socket_cpu", array: true
+    t.string "socket_cpu"
     t.string "form_factor"
-    t.integer "max_memory"
+    t.string "max_memory"
     t.integer "memory_slots"
     t.string "color"
     t.string "rating"
@@ -160,7 +160,7 @@ ActiveRecord::Schema.define(version: 2021_07_17_081433) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
     t.string "image"
-    t.string "supported_memory"
+    t.string "supported_memory", array: true
   end
 
   create_table "psus", force: :cascade do |t|


### PR DESCRIPTION
This PR covers the addition of Scraping capability to the Mobo model. In addition, it also contains the changes made to the mobos table.

Scraper

![Mobo command](https://user-images.githubusercontent.com/72000424/126122136-e73370a2-d542-404e-bf32-77cac1400930.JPG)

![Mobo output](https://user-images.githubusercontent.com/72000424/126122157-1e3857d0-09fe-424d-bffa-c9e4ed9d3db2.JPG)

Table
Changed socket_cpu data type from array to string
Changed supported_memory data type from string to array
Changed max_memory data type from integer to string