### PR TITLE
Feature/pc parts scraper seed

### DIFF
--- a/app/services/scraper.rb
+++ b/app/services/scraper.rb
@@ -2,27 +2,30 @@ require 'kimurai'
 require 'webdrivers'
 
 class Scraper < Kimurai::Base
-  @page = 1
   @engine = :selenium_firefox
   @config = { before_request: {
     delay: 2..4
   } }
+  @@page = 1
 
   def self.process(model)
     @@class = model
     @name = @@class.name
+    @page = @@page
     @start_urls = @@class.url
     crawl!
   end
 
   def parse(response, url:, data: {})
     products = response.xpath("//a[contains(@class, 'productItemLink')]")
-    return if products.empty?
+
+    return unless products.any?
 
     products.each do |a|
       request_to :parse_repo_page, url: absolute_url(a[:href], base: url)
     end
-    @page += 1
+    @@page += 1
+    request_to :parse, url: absolute_url((@@class.url.first + @@page.to_s), base: url)
   end
 
   def parse_repo_page(response, url:, data: {})

--- a/db/migrate/20210720033542_remove_type_column_from_ssds_table.rb
+++ b/db/migrate/20210720033542_remove_type_column_from_ssds_table.rb
@@ -1,0 +1,5 @@
+class RemoveTypeColumnFromSsdsTable < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :ssds, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,20 +223,6 @@ ActiveRecord::Schema.define(version: 2021_07_19_134614) do
     t.string "memory_size"
   end
 
-  create_table "ssd_tables", force: :cascade do |t|
-    t.string "name"
-    t.string "image"
-    t.string "capacity"
-    t.string "type"
-    t.string "form_factor"
-    t.string "nand_flash"
-    t.string "interface"
-    t.string "rating"
-    t.float "price"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "ssds", force: :cascade do |t|
     t.string "name"
     t.string "image"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_134614) do
+ActiveRecord::Schema.define(version: 2021_07_20_033542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,7 +227,6 @@ ActiveRecord::Schema.define(version: 2021_07_19_134614) do
     t.string "name"
     t.string "image"
     t.string "capacity"
-    t.string "type"
     t.string "form_factor"
     t.string "nand_flash"
     t.string "interface"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# Scraper Seeds
+parts = [Ssd, Hdd, CaseFan, Case, CpuFan, Cpu, Gpu, Mobo, Psu, Ram]
+
+parts.each do |part|
+  Scraper.process(part)
+end


### PR DESCRIPTION
This PR covers the addition of the pc parts scraper in the seeds.rb file in order to populate the database with data. In addition, it also covers a fix to the database as well as the scraper function

Seeds.rb

Added Scrape function for various pc parts in the seed file

![image](https://user-images.githubusercontent.com/72000424/126258904-aa7b9050-bb4c-4749-bda6-695dadb85df2.png)

Output
![image](https://user-images.githubusercontent.com/72000424/126258933-aee0220f-e162-49e8-ab00-9a1ce8797c24.png)

Data
![image](https://user-images.githubusercontent.com/72000424/126259004-c24440c5-5c46-40d6-8daa-dbbec64958b2.png)



Scraper.rb

Edited code to allows the scraper to access succeeding pages, not just the first page of the website


Database

Removed "type" column from ssds table. It was not supposed to be there.